### PR TITLE
change regex criteria to match {module code}-{tutorial group}

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -11,7 +11,7 @@ public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric "
             + "or in {Module}-{Tutorial Group} format";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z]+(?:[-][a-zA-Z]+)?$"; // "\p{Alnum}+"
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+(?:[-][a-zA-Z0-9]+)?$"; // "\p{Alnum}+"
 
     public final String tagName;
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric "
+            + "or in {Module}-{Tutorial Group} format";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z]+(?:[-][a-zA-Z]+)?$"; // "\p{Alnum}+"
 
     public final String tagName;
 


### PR DESCRIPTION
tag criteria should only match these formats now:
{alphanumeric}
{alphanumeric}-{alphanumeric}

Invalid matches (non-exhaustive):
-{a-z}-{a-z}-
{a-z}-{a-z}-
-{a-z}-{a-z}
{a-z}-
-{a-z}

To test for more examples visit:
[Regex Tester](https://regex101.com/r/WwQJwX/1)
