### PR TITLE
Add rename function

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -55,6 +55,8 @@ public interface Logic {
      */
     void setAllAddressBookFilePath(Path[] updatedPaths);
 
+    void resetCurrentAddressBook();
+
     /**
      * Add and create a new address book
      */
@@ -64,4 +66,9 @@ public interface Logic {
      * Swaps between the address book
      */
     void swapAddressBook();
+
+    /**
+     * Swaps to the address book
+     */
+    void swapToAddressBook(Path nextAddressBook);
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -57,7 +58,7 @@ public interface Logic {
     /**
      * Add and create a new address book
      */
-    boolean addAddressBook() throws IOException;
+    boolean addAddressBook() throws IOException, DataConversionException;
 
     /**
      * Swaps between the address book

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -20,7 +20,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.util.SampleDataUtil;
-import seedu.address.storage.AddressBookStorage;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.Storage;
 
@@ -92,19 +91,17 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public boolean addAddressBook() throws IOException {
+    public boolean addAddressBook() throws IOException, DataConversionException {
         boolean result = model.addAddressBook();
+        Optional<ReadOnlyAddressBook> addressBookOptional;
+        ReadOnlyAddressBook initialData;
         if (result) {
             Path[] allBooks = model.getAllAddressBookFilePath();
             Path latestBook = allBooks[allBooks.length - 1];
-            try {
-                FileWriter file = new FileWriter(latestBook.toFile());
-                file.close();
-            } catch (IOException e) {
-                logger.warning("Error creating file" + latestBook);
-                throw e;
-            }
-
+            addressBookOptional = storage.readAddressBook();
+            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+            storage.setAddressBook(new JsonAddressBookStorage(latestBook));
+            model.setAddressBook(initialData);
         }
         return result;
     }
@@ -126,8 +123,7 @@ public class LogicManager implements Logic {
             logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
             initialData = new AddressBook();
         }
-        AddressBookStorage newAddressBookStorage = new JsonAddressBookStorage(nextAddressBook);
-        storage.setAddressBook(newAddressBookStorage);
+        storage.setAddressBook(new JsonAddressBookStorage(nextAddressBook));
         model.setAddressBook(initialData);
     }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -114,6 +114,8 @@ public class LogicManager implements Logic {
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
             setActiveAddressBook(latestBook, initialData);
             model.setStoredIndex(allBooks.length - 1);
+            model.setAddressBookFilePath(latestBook);
+            storage.saveAddressBook(initialData);
         }
         return result;
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,6 +1,5 @@
 package seedu.address.logic;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;

--- a/src/main/java/seedu/address/logic/commands/RenameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameCommand.java
@@ -19,10 +19,12 @@ public class RenameCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Renames the current folder "
             + "by the input string.\n"
-            + "Parameters: NAME (must be an alphanumeric String)";
+            + "Parameters: NAME (must be an alphanumeric String with only '-' and '_' allowed)";
 
     public static final String MESSAGE_RENAME_SUCCESS = "Renamed successfully!";
-    public static final String MESSAGE_RENAME_FAILURE = "File name already exists!";
+    public static final String MESSAGE_RENAME_FAILURE = "There is an error creating the file!\n"
+            + "The file has to be in alphanumeric format with only '-' and '_' allowed\n"
+            + "The file cannot be a duplicate";
 
     private final String name;
 

--- a/src/main/java/seedu/address/logic/commands/RenameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameCommand.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Renames the currently stored folder name to a new name
+ */
+public class RenameCommand extends Command {
+    public static final String COMMAND_WORD = "rename";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Renames the current folder "
+            + "by the input string.\n"
+            + "Parameters: NAME (must be an alphanumeric String)";
+
+    public static final String MESSAGE_RENAME_SUCCESS = "Renamed successfully!";
+    public static final String MESSAGE_RENAME_FAILURE = "File name already exists!";
+
+    private final String name;
+
+    /**
+     * @param name of the new book
+     */
+    public RenameCommand(String name) {
+        requireNonNull(name);
+        this.name = name;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        try {
+            model.renameAddressBook(this.name);
+            return new CommandResult(MESSAGE_RENAME_SUCCESS, null, false, false, false, false);
+        } catch (IOException e) {
+            return new CommandResult(MESSAGE_RENAME_FAILURE, null, false, false, false, false);
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RenameCommand)) {
+            return false;
+        }
+
+        // state check
+        RenameCommand s = (RenameCommand) other;
+        return name.equals(s.name);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RenameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameCommand.java
@@ -3,13 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
-import java.util.List;
 
-import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
 
 /**
  * Renames the currently stored folder name to a new name

--- a/src/main/java/seedu/address/logic/commands/RenameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameCommand.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -21,6 +23,7 @@ public class RenameCommand extends Command {
     public static final String MESSAGE_RENAME_FAILURE = "There is an error creating the file!\n"
             + "The file has to be in alphanumeric format with only '-' and '_' allowed\n"
             + "The file cannot be a duplicate";
+    public static final String MESSAGE_RENAME_SAME = "They are the same name!";
 
     private final String name;
 
@@ -36,6 +39,10 @@ public class RenameCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         try {
+            Path newAddressBookFilePath = Paths.get("data" , name + ".json");
+            if (newAddressBookFilePath.equals(model.getUserPrefs().getAddressBookFilePath())) {
+                return new CommandResult(MESSAGE_RENAME_SAME, null, false, false, false, false);
+            }
             model.renameAddressBook(this.name);
             return new CommandResult(MESSAGE_RENAME_SUCCESS, null, false, false, false, false);
         } catch (IOException e) {

--- a/src/main/java/seedu/address/logic/commands/RenameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameCommand.java
@@ -40,7 +40,7 @@ public class RenameCommand extends Command {
         requireNonNull(model);
         try {
             Path newAddressBookFilePath = Paths.get("data" , name + ".json");
-            if (newAddressBookFilePath.equals(model.getUserPrefs().getAddressBookFilePath())) {
+            if (newAddressBookFilePath.toString().equals(model.getUserPrefs().getAddressBookFilePath().toString())) {
                 return new CommandResult(MESSAGE_RENAME_SAME, null, false, false, false, false);
             }
             model.renameAddressBook(this.name);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NewBookCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.RenameCommand;
 import seedu.address.logic.commands.RolesCommand;
 import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.commands.SwapCommand;
@@ -101,6 +102,9 @@ public class AddressBookParser {
 
         case RolesCommand.COMMAND_WORD:
             return new RolesCommandParser().parse(arguments);
+
+        case RenameCommand.COMMAND_WORD:
+            return new RenameCommandParser().parse(arguments);
 
         case ShowCommand.COMMAND_WORD:
             return new ShowCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -136,4 +136,19 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses and checks the validity of file name.
+     */
+    public static String parseRename(String newName) throws ParseException {
+        requireNonNull(newName);
+        String REGEX_PATTERN = "^[A-za-z0-9-_]{1,255}$";
+        String MESSAGE_CONSTRAINTS = "File name is limited to alphanumeric characters, '-' and '_'";
+        String trimmedTag = newName.trim();
+        if (!trimmedTag.matches(REGEX_PATTERN)) {
+            throw new ParseException(MESSAGE_CONSTRAINTS);
+        }
+        return trimmedTag;
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -145,10 +145,11 @@ public class ParserUtil {
         String regexPattern = "^[A-za-z0-9-_]{1,255}$";
         String messageConstraints = "File name is limited to alphanumeric characters, '-' and '_'";
         String trimmedTag = newName.trim();
-        if (!trimmedTag.matches(regexPattern)) {
+        String lowerCase = trimmedTag.toLowerCase();
+        if (!lowerCase.matches(regexPattern)) {
             throw new ParseException(messageConstraints);
         }
-        return trimmedTag;
+        return lowerCase;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -142,11 +142,11 @@ public class ParserUtil {
      */
     public static String parseRename(String newName) throws ParseException {
         requireNonNull(newName);
-        String REGEX_PATTERN = "^[A-za-z0-9-_]{1,255}$";
-        String MESSAGE_CONSTRAINTS = "File name is limited to alphanumeric characters, '-' and '_'";
+        String regexPattern = "^[A-za-z0-9-_]{1,255}$";
+        String messageConstraints = "File name is limited to alphanumeric characters, '-' and '_'";
         String trimmedTag = newName.trim();
-        if (!trimmedTag.matches(REGEX_PATTERN)) {
-            throw new ParseException(MESSAGE_CONSTRAINTS);
+        if (!trimmedTag.matches(regexPattern)) {
+            throw new ParseException(messageConstraints);
         }
         return trimmedTag;
     }

--- a/src/main/java/seedu/address/logic/parser/RenameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RenameCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.RenameCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new RenameCommand object.
+ */
+public class RenameCommandParser implements Parser<RenameCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the RenameCommand
+     * and returns a RenameCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RenameCommand parse(String args) throws ParseException {
+        try {
+            String name = ParserUtil.parseRename(args);
+            return new RenameCommand(name);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RenameCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,5 +1,6 @@
 package seedu.address.model;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
@@ -62,6 +63,9 @@ public interface Model {
 
     /** Returns the next AddressBook */
     Path getNextAddressBookPath();
+
+    /** Renames the current AddressBook */
+    void renameAddressBook(String newName) throws IOException;
 
     /**
      * Creates a new Address Book

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -53,6 +53,8 @@ public interface Model {
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
 
+    void setStoredIndex(int index);
+
     /** Returns all address book's paths*/
     Path[] getAllAddressBookFilePath();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -74,6 +75,11 @@ public class ModelManager implements Model {
     public void setAddressBookFilePath(Path addressBookFilePath) {
         requireNonNull(addressBookFilePath);
         userPrefs.setAddressBookFilePath(addressBookFilePath);
+    }
+
+    @Override
+    public void setStoredIndex(int index) {
+        userPrefs.setStoredIndex(index);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -91,6 +92,11 @@ public class ModelManager implements Model {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public void renameAddressBook(String name) throws IOException {
+        userPrefs.renameFile(name);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -2,6 +2,9 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -9,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.ui.ResultDisplay;
 
 /**
  * Represents User's preferences.
@@ -94,6 +98,17 @@ public class UserPrefs implements ReadOnlyUserPrefs {
             allAddressBookFilePath.add(newBook);
             return true;
         }
+    }
+
+    /**
+     * Renames the current address book
+     */
+    public void renameFile(String name) throws IOException {
+        Path newAddressBookFilePath = Paths.get("data" , name + ".json");
+        Files.move(this.addressBookFilePath, newAddressBookFilePath);
+        Files.delete(this.addressBookFilePath);
+        this.addressBookFilePath = newAddressBookFilePath;
+        allAddressBookFilePath.set(addressBookIndex, newAddressBookFilePath);
     }
 
     public Path getNextAddressBookPath() {

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -88,7 +88,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         } else {
             String newBookName;
             if (allAddressBookFilePath.size() != 0) {
-                newBookName = DEFAULT_ADDRESS_BOOK_NAME + allAddressBookFilePath.size() + ".json";
+                newBookName = DEFAULT_ADDRESS_BOOK_NAME + System.currentTimeMillis() + ".json";
             } else {
                 newBookName = DEFAULT_ADDRESS_BOOK_NAME + ".json";
             }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -2,9 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -13,7 +11,6 @@ import java.util.List;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.ui.ResultDisplay;
 
 /**
  * Represents User's preferences.

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -104,10 +104,9 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void renameFile(String name) throws IOException {
         Path newAddressBookFilePath = Paths.get("data" , name + ".json");
         Files.move(this.addressBookFilePath, newAddressBookFilePath);
-        Files.delete(this.addressBookFilePath);
-        this.addressBookFilePath = newAddressBookFilePath;
-        allAddressBookFilePath.set(addressBookIndex, newAddressBookFilePath);
+        this.allAddressBookFilePath.set(addressBookIndex, newAddressBookFilePath);
     }
+
 
     public Path getNextAddressBookPath() {
         incrementIndex();
@@ -125,8 +124,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     }
 
     private void incrementIndex() {
-        addressBookIndex += 1;
-        addressBookIndex = addressBookIndex % allAddressBookFilePath.size();
+        addressBookIndex = (addressBookIndex + 1) % allAddressBookFilePath.size();
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -182,6 +182,8 @@ public class MainWindow extends UiPart<Stage> {
         try {
             if (!logic.addAddressBook()) {
                 resultDisplay.setFeedbackToUser("Maximum amount of address book created");
+            } else {
+                refreshStatusBar();
             }
         } catch (IOException | DataConversionException e) {
             resultDisplay.setFeedbackToUser("Sorry! Error creating File");

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.RenameCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
@@ -86,7 +87,7 @@ public class MainWindow extends UiPart<Stage> {
     private void setAccelerators() {
         setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
         setAccelerator(swapBook, KeyCombination.valueOf("Shift+Tab"));
-        setAccelerator(swapBook, KeyCombination.valueOf("Ctrl+Shift+N"));
+        setAccelerator(newBook, KeyCombination.valueOf("Ctrl+Shift+N"));
     }
 
     /**
@@ -152,6 +153,14 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Resets what the status bar shows.
+     */
+    public void refreshStatusBar() {
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        statusbarPlaceholder.getChildren().set(0, statusBarFooter.getRoot());
+    }
+
+    /**
      * Opens the help window in a new browser window
      */
     @FXML
@@ -184,9 +193,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleSwap() {
         logic.swapAddressBook();
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
-        statusbarPlaceholder.getChildren().set(0, statusBarFooter.getRoot());
-        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
+        refreshStatusBar();
     }
 
     /**
@@ -228,6 +235,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isNewBook()) {
                 handleNewBook();
+            }
+
+            if (commandResult.getFeedbackToUser().equals(RenameCommand.MESSAGE_RENAME_SUCCESS)) {
+                refreshStatusBar();
             }
 
             if (commandResult.isSwap()) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -43,6 +44,12 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private MenuItem helpMenuItem;
+
+    @FXML
+    private MenuItem swapBook;
+
+    @FXML
+    private MenuItem newBook;
 
     @FXML
     private StackPane personListPanelPlaceholder;
@@ -78,6 +85,8 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setAccelerators() {
         setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
+        setAccelerator(swapBook, KeyCombination.valueOf("Shift+Tab"));
+        setAccelerator(swapBook, KeyCombination.valueOf("Ctrl+Shift+N"));
     }
 
     /**
@@ -164,7 +173,7 @@ public class MainWindow extends UiPart<Stage> {
             if (!logic.addAddressBook()) {
                 resultDisplay.setFeedbackToUser("Maximum amount of address book created");
             }
-        } catch (IOException e) {
+        } catch (IOException | DataConversionException e) {
             resultDisplay.setFeedbackToUser("Sorry! Error creating File");
         }
     }
@@ -173,8 +182,11 @@ public class MainWindow extends UiPart<Stage> {
      * Swaps between the Books
      */
     @FXML
-    private void handleSwap() throws CommandException {
+    private void handleSwap() {
         logic.swapAddressBook();
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        statusbarPlaceholder.getChildren().set(0, statusBarFooter.getRoot());
+        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -191,6 +192,20 @@ public class MainWindow extends UiPart<Stage> {
      * Swaps between the Books
      */
     @FXML
+    private void handleRename() {
+        try {
+            Files.delete(logic.getAddressBookFilePath());
+            logic.resetCurrentAddressBook();
+            refreshStatusBar();
+        } catch (IOException e) {
+            resultDisplay.setFeedbackToUser("Sorry! Error deleting File");
+        }
+    }
+
+    /**
+     * Swaps between the Books
+     */
+    @FXML
     private void handleSwap() {
         logic.swapAddressBook();
         refreshStatusBar();
@@ -238,7 +253,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.getFeedbackToUser().equals(RenameCommand.MESSAGE_RENAME_SUCCESS)) {
-                refreshStatusBar();
+                handleRename();
             }
 
             if (commandResult.isSwap()) {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -26,8 +26,8 @@
       <VBox>
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleNewBook" text="New Book" />
-            <MenuItem mnemonicParsing="false" onAction="#handleSwap" text="Swap Book" />
+            <MenuItem fx:id="newBook" mnemonicParsing="false" onAction="#handleNewBook" text="New Book" />
+            <MenuItem fx:id="swapBook" mnemonicParsing="false" onAction="#handleSwap" text="Swap Book" />
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
           </Menu>
           <Menu mnemonicParsing="false" text="Help">

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -134,6 +134,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void renameAddressBook(String newName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean addAddressBook() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -119,6 +119,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setStoredIndex(int index) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public Path[] getAllAddressBookFilePath() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/NewBookCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NewBookCommandTest.java
@@ -13,7 +13,7 @@ public class NewBookCommandTest {
     private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_help_success() {
+    public void execute_newBook_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_NEW_BOOK_ACKNOWLEDGEMENT, null,
                 false, true, false, false);
         assertCommandSuccess(new NewBookCommand(), model, expectedCommandResult, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/SwapCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SwapCommandTest.java
@@ -13,7 +13,7 @@ public class SwapCommandTest {
     private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_help_success() {
+    public void execute_swap_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_SWAP_ACKNOWLEDGEMENT, null,
                 false, false, true, false);
         assertCommandSuccess(new SwapCommand(), model, expectedCommandResult, expectedModel);


### PR DESCRIPTION
Add:
- `rename` command. This command has the format `rename {new name}`. 
- `new name` only accepts alphanumeric, '-' and '_' characters.

Changes:
- creating new book now automatically swaps to the newly created book.
- `rename` and `swap` changes the bottom status bar.

New Shortcuts:
- `ctrl + shift + n` creates a new file.
- `shift + tab` swaps between files.